### PR TITLE
请升级com.hazelcast:hazelcast组件版本以解决3个安全漏洞

### DIFF
--- a/distributed/pom.xml
+++ b/distributed/pom.xml
@@ -36,8 +36,7 @@
     <name>OrientDB Distributed Server</name>
 
     <properties>
-        <hz.version>3.12.8</hz.version>
-        <javac.src.version>1.6</javac.src.version>
+        <hz.version>3.12.13-SNAPSHOT</hz.version>javac.src.version>1.6</javac.src.version>
         <javac.target.version>1.6</javac.target.version>
         <jar.manifest.mainclass>com.orientechnologies.orient.server.OServerMain</jar.manifest.mainclass>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
将 **com.hazelcast:hazelcast** 组件从3.12.8 版本升级至 3.12.13-SNAPSHOT版本,
用于修复以下安全漏洞：


序号 | 漏洞编号 | 漏洞标题 | 漏洞级别
-- | -- | -- | --
1 | [MPS-2022-12396](https://www.oscs1024.com/hd/MPS-2022-12396) | com.hazelcast:hazelcast 存在XXE漏洞 | 中危
2 | [MPS-2022-1589](https://www.oscs1024.com/hd/MPS-2022-1589) | Hazelcast<5.1 存在XXE漏洞 | 严重
3 | [MPS-2022-52086](https://www.oscs1024.com/hd/MPS-2022-52086) | hazelcast 存在身份验证不当漏洞 | 高危
  |   |   |   


<br/>

_注意 ：此 PR 由您（或拥有此仓库权限的其他维护者）授权 [墨菲安全](https://www.murphysec.com) 打开_

了解更多：
- [如何快速修复代码安全问题](https://www.murphysec.com/docs/faqs/security-issues/how-to-quick-fixes.html)
